### PR TITLE
fix: add new stack to loops structures 

### DIFF
--- a/exemploGC.y
+++ b/exemploGC.y
@@ -150,11 +150,10 @@ cmd :  exp { System.out.println("\tPOPL %EAX"); } ';' // permitir qualquer expre
 	| FOR '('
     for_opt_exp ';' //inicializador do for(sem label)
     {
-        pRot.push(proxRot);//label do for loop
 		lpRot.push(proxRot);//estrutura de controle de loop 
 		proxRot += 4;//salva 4 labels na pilha (for_opt_exp(exp;;exp), for_cond(;exp;), cmd({}))
         
-		System.out.printf("rot_%02d:\n", (int)pRot.peek() + 2);//mover para a posicao do for_cond
+		System.out.printf("rot_%02d:\n", (int)lpRot.peek() + 2);//mover para a posicao do for_cond
     }
     for_cond ';' //condicao do for
     {
@@ -162,25 +161,24 @@ cmd :  exp { System.out.println("\tPOPL %EAX"); } ';' // permitir qualquer expre
         
 		System.out.println("\tCMPL $0, %EAX");//compara com 0 a condicao do for
 
-        System.out.printf("\tJE rot_%02d\n", (int)pRot.peek() + 1);//jump equals,se falso, pula para o final do for
+        System.out.printf("\tJE rot_%02d\n", (int)lpRot.peek() + 1);//jump equals,se falso, pula para o final do for
 
-        System.out.printf("\tJMP rot_%02d\n", (int)pRot.peek() + 3);//se verdadeiro, pula para o corpo do for
+        System.out.printf("\tJMP rot_%02d\n", (int)lpRot.peek() + 3);//se verdadeiro, pula para o corpo do for
 
-        System.out.printf("rot_%02d:\n", pRot.peek());//pega o label do for_opt_exp(incrementador)
+        System.out.printf("rot_%02d:\n", lpRot.peek());//pega o label do for_opt_exp(incrementador)
     }
     for_opt_exp ')' //incrementador do for
     {
-        System.out.printf("\tJMP rot_%02d\n", (int)pRot.peek() + 2);//vai para o label do for_cond
+        System.out.printf("\tJMP rot_%02d\n", (int)lpRot.peek() + 2);//vai para o label do for_cond
 
-        System.out.printf("rot_%02d:\n", (int)pRot.peek() + 3);//pega o label do corpo do for
+        System.out.printf("rot_%02d:\n", (int)lpRot.peek() + 3);//pega o label do corpo do for
     }
     cmd //corpo do for
     {
-        System.out.printf("\tJMP rot_%02d\n", pRot.peek());//vai para o label do for_opt_exp(incrementador)
+        System.out.printf("\tJMP rot_%02d\n", lpRot.peek());//vai para o label do for_opt_exp(incrementador)
         
-        System.out.printf("rot_%02d:\n", (int)pRot.peek() + 1);//pega o label do final do for
-        //limpa as pilhas para o break e continue
-		pRot.pop();
+        System.out.printf("rot_%02d:\n", (int)lpRot.peek() + 1);//pega o label do final do for
+        //limpa a pilha para o break e continue
 		lpRot.pop();
     }
 	| BREAK ';' {


### PR DESCRIPTION
### AI-GENERATED SUMMARY

This pull request introduces improvements to loop control structures in the `exemploGC.y` file by adding a new stack (`lpRot`) for better management of `break` and `continue` statements, enhancing robustness and alignment with C-style semantics, and refining label handling for loops. Below are the most significant changes grouped by theme:

### Loop Control Enhancements:

* Added a new stack `lpRot` to manage loop control structures (`BREAK` and `CONTINUE`) separately from `pRot`. This ensures better organization and simplifies label handling for loops. (`[exemploGC.yR293](diffhunk://#diff-304c921b989a2c71cf3c624a86999911a0c437cc57eac9fa177cf854a84f68a5R293)`)

* Updated `BREAK` and `CONTINUE` statements to use `lpRot` for determining the correct labels, improving clarity and robustness in loop control flow. (`[exemploGC.yL174-R194](diffhunk://#diff-304c921b989a2c71cf3c624a86999911a0c437cc57eac9fa177cf854a84f68a5L174-R194)`)

### Robustness and Alignment with C Semantics:

* Modified the `DO-WHILE` loop condition to use `CMPL $0, %EAX` instead of `CMPL $1, %EAX`, aligning the logic with C conventions where `0` is false and any other value is true. (`[exemploGC.yR116-L129](diffhunk://#diff-304c921b989a2c71cf3c624a86999911a0c437cc57eac9fa177cf854a84f68a5R116-L129)`)

### Label Management Refinements:

* Enhanced label handling for `WHILE`, `DO-WHILE`, and `FOR` loops by adding comments and refining label allocation logic, ensuring better readability and maintainability. (`[[1]](diffhunk://#diff-304c921b989a2c71cf3c624a86999911a0c437cc57eac9fa177cf854a84f68a5L102-R105)`, `[[2]](diffhunk://#diff-304c921b989a2c71cf3c624a86999911a0c437cc57eac9fa177cf854a84f68a5R116-L129)`, `[[3]](diffhunk://#diff-304c921b989a2c71cf3c624a86999911a0c437cc57eac9fa177cf854a84f68a5L147-R159)`)